### PR TITLE
remove xwaretech domains

### DIFF
--- a/newsletter/black_list.txt
+++ b/newsletter/black_list.txt
@@ -3225,9 +3225,6 @@ xperiae5.com
 xrap.de
 xrho.com
 xvx.us
-xwaretech.com
-xwaretech.info
-xwaretech.net
 xww.ro
 xxhamsterxx.ga
 xxi2.com

--- a/staticfiles/lists/email_black_list.txt
+++ b/staticfiles/lists/email_black_list.txt
@@ -3225,9 +3225,6 @@ xperiae5.com
 xrap.de
 xrho.com
 xvx.us
-xwaretech.com
-xwaretech.info
-xwaretech.net
 xww.ro
 xxhamsterxx.ga
 xxi2.com

--- a/terrameiga/static/lists/email_black_list.txt
+++ b/terrameiga/static/lists/email_black_list.txt
@@ -3225,9 +3225,6 @@ xperiae5.com
 xrap.de
 xrho.com
 xvx.us
-xwaretech.com
-xwaretech.info
-xwaretech.net
 xww.ro
 xxhamsterxx.ga
 xxi2.com


### PR DESCRIPTION
These were mistakenly added to blacklist. Many years ago they pointed to mailinator (a disposable email service) but this has not been the case for a decade. 